### PR TITLE
Update BurnTogether.version

### DIFF
--- a/Distribution/GameData/BurnTogether/BurnTogether.version
+++ b/Distribution/GameData/BurnTogether/BurnTogether.version
@@ -7,16 +7,21 @@
     "MAJOR": 0, 
     "MINOR": 0,
     "PATCH": 7,
-	  "BUILD": 2
+	"BUILD": 2
   },
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 2,
-    "PATCH": 0
+    "PATCH": 2
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
-	  "MINOR": 2,
-	  "PATCH": 0
+	"MINOR": 2,
+	"PATCH": 0
+  },
+  "KSP_VERSION_MAX": {
+    "MAJOR": 1,
+    "MINOR": 2,
+	"PATCH": 2
   }
 }


### PR DESCRIPTION
Release info says 0.0.7.2 is recompiled for 1.2.2. This change should tell AVC to stop complaining.